### PR TITLE
Support UNB InterchangeHeader segment

### DIFF
--- a/example/printing-segments.php
+++ b/example/printing-segments.php
@@ -11,6 +11,7 @@ $fileContent = file_get_contents(__DIR__ . '/edifact-sample.edi');
 $messages = EdifactParser::createWithDefaultSegments()->parse($fileContent);
 
 $printer = ConsolePrinter::createWithHeaders([
+    'UNB',
     'UNH',
     'BGM',
     'DTM',

--- a/src/Segments/SegmentFactory.php
+++ b/src/Segments/SegmentFactory.php
@@ -16,6 +16,7 @@ final class SegmentFactory implements SegmentFactoryInterface
     /** @var array<string,string> */
     public const DEFAULT_SEGMENTS = [
         'UNH' => UNHMessageHeader::class,
+        'UNB' => UNBInterchangeHeader::class,
         'DTM' => DTMDateTimePeriod::class,
         'NAD' => NADNameAddress::class,
         'MEA' => MEADimensions::class,

--- a/src/Segments/UNBInterchangeHeader.php
+++ b/src/Segments/UNBInterchangeHeader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Segments;
+
+use EdifactParser\Exception\MissingSubId;
+
+/** @psalm-immutable */
+final class UNBInterchangeHeader implements SegmentInterface
+{
+    private array $rawValues;
+
+    public function __construct(array $rawValues)
+    {
+        $this->rawValues = $rawValues;
+    }
+
+    public function tag(): string
+    {
+        return 'UNB';
+    }
+
+    public function subId(): string
+    {
+        if (!isset($this->rawValues[1][0])) {
+            throw new MissingSubId('[1][0]', $this->rawValues);
+        }
+
+        return (string) $this->rawValues[1][0];
+    }
+
+    public function rawValues(): array
+    {
+        return $this->rawValues;
+    }
+}

--- a/tests/Unit/Segments/SegmentFactoryTest.php
+++ b/tests/Unit/Segments/SegmentFactoryTest.php
@@ -11,6 +11,7 @@ use EdifactParser\Segments\MEADimensions;
 use EdifactParser\Segments\NADNameAddress;
 use EdifactParser\Segments\PCIPackageId;
 use EdifactParser\Segments\SegmentFactory;
+use EdifactParser\Segments\UNBInterchangeHeader;
 use EdifactParser\Segments\UNHMessageHeader;
 use EdifactParser\Segments\UnknownSegment;
 use EdifactParser\Segments\UNTMessageFooter;
@@ -27,6 +28,7 @@ final class SegmentFactoryTest extends TestCase
         $factory = SegmentFactory::withDefaultSegments();
 
         self::assertInstanceOf(UNHMessageHeader::class, $factory->createSegmentFromArray(['UNH']));
+        self::assertInstanceOf(UNBInterchangeHeader::class, $factory->createSegmentFromArray(['UNB']));
         self::assertInstanceOf(DTMDateTimePeriod::class, $factory->createSegmentFromArray(['DTM']));
         self::assertInstanceOf(NADNameAddress::class, $factory->createSegmentFromArray(['NAD']));
         self::assertInstanceOf(MEADimensions::class, $factory->createSegmentFromArray(['MEA']));

--- a/tests/Unit/Segments/UNBInterchangeHeaderTest.php
+++ b/tests/Unit/Segments/UNBInterchangeHeaderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit\Segments;
+
+use EdifactParser\Exception\MissingSubId;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use PHPUnit\Framework\TestCase;
+
+final class UNBInterchangeHeaderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function segment_values(): void
+    {
+        $rawValues = [
+            'UNB',
+            ['UNOC', '3'],
+            ['9457386', '30'],
+            ['73130012', '30'],
+            ['19101', '118'],
+            '8',
+            'MPM 2.19',
+            '1424',
+        ];
+        $segment = new UNBInterchangeHeader($rawValues);
+
+        self::assertEquals('UNB', $segment->tag());
+        self::assertEquals('UNOC', $segment->subId());
+        self::assertEquals($rawValues, $segment->rawValues());
+    }
+
+    /**
+     * @test
+     */
+    public function missing_sub_id(): void
+    {
+        $segment = new UNBInterchangeHeader(['UNB']);
+        $this->expectException(MissingSubId::class);
+        $segment->subId();
+    }
+}


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/Chemaclass/EdifactParser/issues/32

## 🔖 Changes

The UNB segment is a global segment related to all messages ([source](https://unece.org/fileadmin/DAM/trade/edifact/untdid/d422_s.htm#structures)), so in case it appears it will be prepended to every message as another normal segment within the same message; this way you have access to the UNB in all messages.

<img width="449" alt="Screenshot 2023-02-09 at 21 41 24" src="https://user-images.githubusercontent.com/5256287/217934172-d917030a-1903-42ea-a586-98aaa3679f39.png">

