### PR TITLE
Global segments are grouped separately

### DIFF
--- a/example/extracting-data.php
+++ b/example/extracting-data.php
@@ -8,8 +8,8 @@ use EdifactParser\EdifactParser;
 use EdifactParser\Segments\SegmentInterface;
 
 $fileContent = file_get_contents(__DIR__ . '/edifact-sample.edi');
-$messages = EdifactParser::createWithDefaultSegments()->parse($fileContent);
-$firstMessage = reset($messages);
+$parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+$firstMessage = $parserResult->transactionMessages()[0];
 
 /** @var SegmentInterface $cnNadSegment */
 $cnNadSegment = $firstMessage->segmentByTagAndSubId('NAD', 'CN');

--- a/example/printing-segments.php
+++ b/example/printing-segments.php
@@ -8,7 +8,7 @@ use EdifactParser\EdifactParser;
 use EdifactParser\IO\ConsolePrinter;
 
 $fileContent = file_get_contents(__DIR__ . '/edifact-sample.edi');
-$messages = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+$parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
 
 $printer = ConsolePrinter::createWithHeaders([
     'UNB',
@@ -22,8 +22,17 @@ $printer = ConsolePrinter::createWithHeaders([
     'UNT',
 ]);
 
-foreach ($messages as $i => $message) {
-    print "Message number: {$i}\n";
+
+print "##################\n";
+print "# Global segments:\n";
+print "##################\n";
+$printer->printMessage($parserResult->globalSegments());
+print PHP_EOL;
+
+foreach ($parserResult->transactionMessages() as $i => $message) {
+    print "###################\n";
+    print "# Message number: {$i}\n";
+    print "###################\n";
     $printer->printMessage($message);
     print PHP_EOL;
 }

--- a/src/EdifactParser.php
+++ b/src/EdifactParser.php
@@ -30,10 +30,7 @@ final class EdifactParser
         return new self(SegmentFactory::withDefaultSegments());
     }
 
-    /**
-     * @return list<TransactionMessage>
-     */
-    public function parse(string $fileContent): array
+    public function parse(string $fileContent): ParserResult
     {
         $parser = new Parser($fileContent);
         $errors = $parser->errors();

--- a/src/IO/ConsolePrinter.php
+++ b/src/IO/ConsolePrinter.php
@@ -26,7 +26,11 @@ final class ConsolePrinter implements PrinterInterface
     public function printMessage(TransactionMessage $message): void
     {
         foreach ($this->segmentNames as $segmentName) {
-            $this->printSegment($message->segmentsByTag($segmentName));
+            $render = $message->segmentsByTag($segmentName);
+            if ($render === []) {
+                continue;
+            }
+            $this->printSegment($render);
         }
     }
 

--- a/src/ParserResult.php
+++ b/src/ParserResult.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+final class ParserResult
+{
+    /**
+     * @param list<TransactionMessage> $transactionMessages
+     */
+    public function __construct(
+        private TransactionMessage $globalSegments,
+        private array $transactionMessages,
+    ) {
+    }
+
+    public function globalSegments(): TransactionMessage
+    {
+        return $this->globalSegments;
+    }
+
+    public function transactionMessages(): array
+    {
+        return $this->transactionMessages;
+    }
+}

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -33,6 +33,7 @@ EDI;
     {
         $fileContent = <<<EDI
 UNA:+.? '
+UNB+UNOC:1+2:3'
 UNH+1+IFTMIN:S:93A:UN:PN001'
 UNT+19+1'
 UNH+2+IFTMIN:S:94A:UN:PN002'
@@ -41,8 +42,10 @@ UNH+3+IFTMIN:S:94A:UN:PN003'
 UNT+19+3'
 UNZ+3+4'
 EDI;
-        $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
-        self::assertCount(3, $transactionResult);
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+
+        self::assertCount(2, $parserResult->globalSegments());
+        self::assertCount(3, $parserResult->transactionMessages());
     }
 
     /**
@@ -58,9 +61,9 @@ CNT+11:1:PCE'
 UNT+19+1'
 UNZ+1+3'
 EDI;
-        $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
-        self::assertCount(1, $transactionResult);
-        $message = $transactionResult[0];
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+        self::assertCount(1, $parserResult->transactionMessages());
+        $message = $parserResult->transactionMessages()[0];
 
         /** @var UNHMessageHeader $unh */
         $unh = $message->segmentByTagAndSubId('UNH', '1');
@@ -93,9 +96,9 @@ UNT+19+1'
 UNZ+1+3'
 EDI;
         $parser = new EdifactParser(new TestingSegmentFactory('CUSTOM'));
-        $transactionResult = $parser->parse($fileContent);
-        self::assertCount(1, $transactionResult);
-        $message = $transactionResult[0];
+        $parserResult = $parser->parse($fileContent);
+        self::assertCount(1, $parserResult->transactionMessages());
+        $message = $parserResult->transactionMessages()[0];
 
         /** @var SegmentInterface $custom */
         $custom = $message->segmentByTagAndSubId('CUSTOM', 'anyKey');
@@ -120,8 +123,8 @@ CNT+11:1:PCE'
 UNT+19+1'
 UNZ+1+3'
 EDI;
-        $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
-        $message = $transactionResult[0];
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+        $message = $parserResult->transactionMessages()[0];
 
         self::assertNotNull($message->segmentByTagAndSubId('UNK', 'first'));
         self::assertNotNull($message->segmentByTagAndSubId('UNK', 'second'));
@@ -144,8 +147,8 @@ CNT+11:1:PCE'
 UNT+19+1'
 UNZ+1+3'
 EDI;
-        $transactionResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
-        $message = $transactionResult[0];
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+        $message = $parserResult->transactionMessages()[0];
 
         self::assertNotNull($message->lineItemById(1)?->segmentByTagAndSubId('UNK', 'first'));
         self::assertNotNull($message->lineItemById(2)?->segmentByTagAndSubId('UNK', 'first'));


### PR DESCRIPTION
## 📚 Description

With the previous PR https://github.com/Chemaclass/edifact-parser/pull/33 I introduced the UNB global segment into all messages. However, it could be more "correct" if the parse() would return something like:

- `ParserResult` with:
  - `GlobalSegments` <- Here you would find the UNA, UNB, UNZ
  - `list<TransactionMessages>`


## 🔖 Changes

- The `parse()` returns a `ParserResult` which contains 
```php
public function __construct(
    private TransactionMessage $globalSegments,
    private array $transactionMessages,
) {
}
```
