### PR TITLE
Fix LIN segments with wrong end

### DIFF
--- a/src/MessageDataBuilder/Builder.php
+++ b/src/MessageDataBuilder/Builder.php
@@ -9,9 +9,13 @@ use EdifactParser\Segments\LINLineItem;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNSSectionControl;
 
+use function in_array;
+
 class Builder
 {
     use MultipleBuilderWrapper;
+
+    private const SUMMARY_TAGS = ['UNS', 'CNT', 'UNT'];
 
     public function __construct()
     {
@@ -21,6 +25,13 @@ class Builder
     public function addSegment(SegmentInterface $segment): self
     {
         $this->updateState($segment);
+
+        // Always add summary segments to the main builder
+        if (in_array($segment->tag(), self::SUMMARY_TAGS)) {
+            $this->builders[0]->addSegment($segment);
+            return $this;
+        }
+
         $this->currentBuilder->addSegment($segment);
         return $this;
     }

--- a/src/MessageDataBuilder/Builder.php
+++ b/src/MessageDataBuilder/Builder.php
@@ -11,7 +11,7 @@ use EdifactParser\Segments\UNSSectionControl;
 
 use function in_array;
 
-class Builder
+final class Builder
 {
     use MultipleBuilderWrapper;
 

--- a/src/MessageDataBuilder/DetailsSectionBuilder.php
+++ b/src/MessageDataBuilder/DetailsSectionBuilder.php
@@ -10,12 +10,16 @@ class DetailsSectionBuilder implements BuilderInterface
 {
     use MultipleBuilderWrapper;
 
+    private const BEGINNING_TAGS = ['LIN'];
+    private const ENDING_TAGS = ['UNS', 'UNT'];
+
     public function addSegment(SegmentInterface $segment): self
     {
-        if ($segment->tag() == 'LIN') {
+        if (in_array($segment->tag(), self::BEGINNING_TAGS)) {
             $this->setCurrentBuilder(new SimpleBuilder(), $segment->subId());
+        } elseif (in_array($segment->tag(), self::ENDING_TAGS)) {
+            $this->setCurrentBuilder(new SimpleBuilder(), $segment->tag());
         }
-
         $this->currentBuilder->addSegment($segment);
 
         return $this;

--- a/src/MessageDataBuilder/DetailsSectionBuilder.php
+++ b/src/MessageDataBuilder/DetailsSectionBuilder.php
@@ -6,7 +6,7 @@ namespace EdifactParser\MessageDataBuilder;
 
 use EdifactParser\Segments\SegmentInterface;
 
-class DetailsSectionBuilder implements BuilderInterface
+final class DetailsSectionBuilder implements BuilderInterface
 {
     use MultipleBuilderWrapper;
 

--- a/src/MessageDataBuilder/DetailsSectionBuilder.php
+++ b/src/MessageDataBuilder/DetailsSectionBuilder.php
@@ -14,15 +14,11 @@ class DetailsSectionBuilder implements BuilderInterface
 
     public function addSegment(SegmentInterface $segment): self
     {
-        // Only handle LIN and its related segments
         if ($segment->tag() === self::LINE_ITEM_TAG) {
             $this->setCurrentBuilder(new SimpleBuilder(), $segment->subId());
-            $this->currentBuilder->addSegment($segment);
-        } elseif ($this->currentBuilder !== null) {
-            // Add other segments only if we're inside a line item
-            $this->currentBuilder->addSegment($segment);
         }
 
+        $this->currentBuilder->addSegment($segment);
         return $this;
     }
 

--- a/src/MessageDataBuilder/MultipleBuilderWrapper.php
+++ b/src/MessageDataBuilder/MultipleBuilderWrapper.php
@@ -6,17 +6,19 @@ namespace EdifactParser\MessageDataBuilder;
 
 trait MultipleBuilderWrapper
 {
-    private array $builders;
+    /** @var array<string|int,BuilderInterface> */
+    private array $builders = [];
+
     private BuilderInterface $currentBuilder;
 
     private function setCurrentBuilder(BuilderInterface $builder, string|int|null $index = null): void
     {
         $this->currentBuilder = $builder;
 
-        if ($index == null) {
+        if ($index === null) {
             $this->builders[] = $builder;
         } else {
-            $this->builders[$index] = $builder;
+            $this->builders[$index] = $builder; /** @psalm-suppress InvalidPropertyAssignmentValue */
         }
     }
 }

--- a/src/MessageDataBuilder/SimpleBuilder.php
+++ b/src/MessageDataBuilder/SimpleBuilder.php
@@ -6,7 +6,7 @@ namespace EdifactParser\MessageDataBuilder;
 
 use EdifactParser\Segments\SegmentInterface;
 
-class SimpleBuilder implements BuilderInterface
+final class SimpleBuilder implements BuilderInterface
 {
     protected array $data = [];
 

--- a/src/TransactionMessage.php
+++ b/src/TransactionMessage.php
@@ -19,8 +19,8 @@ final class TransactionMessage implements Countable
     use HasRetrievableSegments;
 
     /**
-     * @param array<string, array<string, SegmentInterface>> $groupedSegments
-     * @param array<string, LineItem> $lineItems
+     * @param  array<string, array<string, SegmentInterface>>  $groupedSegments
+     * @param  array<string, LineItem>  $lineItems
      */
     public function __construct(
         private array $groupedSegments,
@@ -65,7 +65,7 @@ final class TransactionMessage implements Countable
 
     public function lineItemById(string|int $lineItemId): ?LineItem
     {
-        return $this->lineItems[(string)$lineItemId] ?? null;
+        return $this->lineItems[(string) $lineItemId] ?? null;
     }
 
     /**

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace EdifactParser\Tests\Functional;
 
 use EdifactParser\EdifactParser;
-use EdifactParser\LineItem;
 use EdifactParser\Segments\CNTControl;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNHMessageHeader;
@@ -143,7 +142,7 @@ EDI;
         self::assertNotNull($message->lineItemById(2)?->segmentByTagAndSubId('UNK', 'first'));
     }
 
-    public function test_handles_lin_segments(): void
+    public function test_handles_uns_cnt_outside_lin_segments(): void
     {
         $fileContent = <<<EDI
 UNA:+.?'
@@ -168,16 +167,9 @@ EDI;
         self::assertCount(1, $parserResult->transactionMessages());
 
         $message = $parserResult->transactionMessages()[0];
-        self::assertSame([1, 2, 'UNS', 'UNT'], array_keys($message->lineItems()));
+        self::assertCount(2, $message->lineItems());
 
-        $unsLine = $message->lineItemById('UNS');
-        self::assertEquals(new LineItem([
-            'UNS' => [
-                'S\'' => new UNSSectionControl(['UNS', 'S\'']),
-            ],
-            'CNT' => [
-                '2' => new CNTControl(['CNT', ['2', '2\'']]),
-            ],
-        ]), $unsLine);
+        self::assertEquals(['S\'' => new UNSSectionControl(['UNS', 'S\''])], $message->allSegments()['UNS']);
+        self::assertEquals(['2' => new CNTControl(['CNT', ['2', '2\'']])], $message->allSegments()['CNT']);
     }
 }

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -7,11 +7,9 @@ namespace EdifactParser\Tests\Functional;
 use EdifactParser\EdifactParser;
 use EdifactParser\LineItem;
 use EdifactParser\Segments\CNTControl;
-use EdifactParser\Segments\LINLineItem;
-use EdifactParser\Segments\PRIPrice;
-use EdifactParser\Segments\QTYQuantity;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNHMessageHeader;
+use EdifactParser\Segments\UNSSectionControl;
 use EdifactParser\Segments\UNTMessageFooter;
 use PHPUnit\Framework\TestCase;
 
@@ -170,13 +168,16 @@ EDI;
         self::assertCount(1, $parserResult->transactionMessages());
 
         $message = $parserResult->transactionMessages()[0];
-        self::assertCount(2, $message->lineItems());
+        self::assertSame([1, 2, 'UNS', 'UNT'], array_keys($message->lineItems()));
 
         $unsLine = $message->lineItemById('UNS');
         self::assertEquals(new LineItem([
-            'LIN' => ['1' => new LINLineItem(['LIN', '1'])],
-            'QTY' => ['21' => new QTYQuantity(['QTY', ['23', '8']])],
-            'PRI' => ['AAA' => new PRIPrice(['PRI', '5.00'])],
+            'UNS' => [
+                'S\'' => new UNSSectionControl(['UNS', 'S\'']),
+            ],
+            'CNT' => [
+                '2' => new CNTControl(['CNT', ['2', '2\'']]),
+            ],
         ]), $unsLine);
     }
 }


### PR DESCRIPTION
## 📚 Description

Related https://github.com/Chemaclass/edifact-parser/issues/42

Right now the UNS, CNT, UNT elements gets inside the LIN segment, but this is wrong

## 🔖 Changes

- `TransactionMessage::groupedSegments()` contains UNS, CNT, UNT
