### PR TITLE
Use BREAK_LINEITEM_TAGS with UNS, CNT, UNT

### DIFF
--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -8,7 +8,6 @@ use EdifactParser\EdifactParser;
 use EdifactParser\Segments\CNTControl;
 use EdifactParser\Segments\SegmentInterface;
 use EdifactParser\Segments\UNHMessageHeader;
-use EdifactParser\Segments\UNSSectionControl;
 use EdifactParser\Segments\UNTMessageFooter;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Functional/EdifactParserTest.php
+++ b/tests/Functional/EdifactParserTest.php
@@ -142,7 +142,7 @@ EDI;
         self::assertNotNull($message->lineItemById(2)?->segmentByTagAndSubId('UNK', 'first'));
     }
 
-    public function test_handles_uns_cnt_outside_lin_segments(): void
+    public function test_handles_cnt_outside_lin_segments(): void
     {
         $fileContent = <<<EDI
 UNA:+.?'
@@ -169,7 +169,27 @@ EDI;
         $message = $parserResult->transactionMessages()[0];
         self::assertCount(2, $message->lineItems());
 
-        self::assertEquals(['S\'' => new UNSSectionControl(['UNS', 'S\''])], $message->allSegments()['UNS']);
         self::assertEquals(['2' => new CNTControl(['CNT', ['2', '2\'']])], $message->allSegments()['CNT']);
+    }
+
+    public function test_segments_after_cnt_are_added_to_summary_until_next_lin(): void
+    {
+        $fileContent = <<<EDI
+UNA:+.?'
+UNH+1+ORDERS:D:96A:UN:EAN008'
+LIN+1'
+QTY+21:10'
+CNT+2:2'
+RFF+ON:123'
+UNT+13+1'
+UNZ+1+ORDER001'
+EDI;
+
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+        $message = $parserResult->transactionMessages()[0];
+
+        self::assertCount(1, $message->lineItems());
+        self::assertArrayHasKey('RFF', $message->allSegments());
+        self::assertNotEmpty($message->segmentsByTag('RFF'));
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/Chemaclass/edifact-parser/issues/42

## 📚 Description

In EDIFACT, the UNS segment does not belong to a LIN segment group. Instead, it serves as a section separator within a message.

The UNS (Section Control) segment is used to logically divide sections of a message. It typically appears after the list of line items (LIN segments and their children like QTY, PRI, etc.), to separate the detail section from the summary section.

### Typical Structure of an ORDERS Message
```
UNH+...            ← Message header
BGM+...            ← Beginning of message
DTM+...            ← Date/time
NAD+...            ← Name and address
...
LIN+...            ← Start of detail section (line items)
QTY+...            ← Quantity related to the line item
PRI+...            ← Price
...
UNS+S              ← Section separator (marks start of summary section)
CNT+...            ← Control totals
UNT+...            ← Message trailer
```

### Interpretation

- The UNS segment should be at the same level as LIN, not inside it.
- It marks the end of the detail section and the beginning of the summary section.
- Your parser should not associate UNS with a LIN group, and therefore it should appear in allSegments() directly under the message.

