### PR TITLE
Implement context stack parser

### DIFF
--- a/src/ContextSegment.php
+++ b/src/ContextSegment.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Segments\SegmentInterface;
+
+final class ContextSegment
+{
+    /**
+     * @param list<ContextSegment|SegmentInterface> $children
+     */
+    public function __construct(
+        private SegmentInterface $segment,
+        private array $children = [],
+    ) {
+    }
+
+    public function segment(): SegmentInterface
+    {
+        return $this->segment;
+    }
+
+    /**
+     * @return list<ContextSegment|SegmentInterface>
+     */
+    public function children(): array
+    {
+        return $this->children;
+    }
+
+    public function addChild(ContextSegment|SegmentInterface $child): void
+    {
+        $this->children[] = $child;
+    }
+}

--- a/src/ContextSegment.php
+++ b/src/ContextSegment.php
@@ -30,7 +30,7 @@ final class ContextSegment
         return $this->children;
     }
 
-    public function addChild(ContextSegment|SegmentInterface $child): void
+    public function addChild(self|SegmentInterface $child): void
     {
         $this->children[] = $child;
     }

--- a/src/ContextStackParser.php
+++ b/src/ContextStackParser.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser;
+
+use EdifactParser\Segments\SegmentInterface;
+
+final class ContextStackParser
+{
+    /** @var list<string> */
+    private const CONTEXT_TAGS = ['NAD', 'LIN', 'DOC'];
+
+    /** @var list<string> */
+    private const CHILD_TAGS = ['COM', 'CTA', 'PIA', 'IMD', 'MEA', 'QTY', 'PRI', 'TAX', 'DTM', 'MOA'];
+
+    /**
+     * @return list<ContextSegment>
+     */
+    public function parse(SegmentInterface ...$segments): array
+    {
+        $result = [];
+        $current = null;
+
+        foreach ($segments as $segment) {
+            $tag = $segment->tag();
+
+            if (in_array($tag, self::CONTEXT_TAGS, true)) {
+                $context = new ContextSegment($segment);
+                $result[] = $context;
+                $current = $context;
+                continue;
+            }
+
+            if (in_array($tag, self::CHILD_TAGS, true) && $current !== null) {
+                $current->addChild($segment);
+                continue;
+            }
+
+            if ($tag === 'UNT') {
+                $current = null;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/ContextStackParser.php
+++ b/src/ContextStackParser.php
@@ -6,6 +6,8 @@ namespace EdifactParser;
 
 use EdifactParser\Segments\SegmentInterface;
 
+use function in_array;
+
 final class ContextStackParser
 {
     /** @var list<string> */

--- a/tests/Unit/ContextStackParserTest.php
+++ b/tests/Unit/ContextStackParserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\ContextStackParser;
+use EdifactParser\ContextSegment;
+use EdifactParser\Segments\LINLineItem;
+use EdifactParser\Segments\NADNameAddress;
+use EdifactParser\Segments\QTYQuantity;
+use EdifactParser\Segments\UNTMessageFooter;
+use EdifactParser\Segments\UnknownSegment;
+use PHPUnit\Framework\TestCase;
+
+final class ContextStackParserTest extends TestCase
+{
+    /** @test */
+    public function groups_segments_by_context(): void
+    {
+        $nad = new NADNameAddress(['NAD', 'CN']);
+        $com = new UnknownSegment(['COM', '123:TE']);
+        $lin = new LINLineItem(['LIN', '1']);
+        $qty = new QTYQuantity(['QTY', ['21', '5']]);
+        $unt = new UNTMessageFooter(['UNT', '19', '1']);
+
+        $parser = new ContextStackParser();
+        $result = $parser->parse($nad, $com, $lin, $qty, $unt);
+
+        self::assertEquals([
+            new ContextSegment($nad, [$com]),
+            new ContextSegment($lin, [$qty]),
+        ], $result);
+    }
+}

--- a/tests/Unit/ContextStackParserTest.php
+++ b/tests/Unit/ContextStackParserTest.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace EdifactParser\Tests\Unit;
 
-use EdifactParser\ContextStackParser;
 use EdifactParser\ContextSegment;
+use EdifactParser\ContextStackParser;
 use EdifactParser\Segments\LINLineItem;
 use EdifactParser\Segments\NADNameAddress;
 use EdifactParser\Segments\QTYQuantity;
-use EdifactParser\Segments\UNTMessageFooter;
 use EdifactParser\Segments\UnknownSegment;
+use EdifactParser\Segments\UNTMessageFooter;
 use PHPUnit\Framework\TestCase;
 
 final class ContextStackParserTest extends TestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function groups_segments_by_context(): void
     {
         $nad = new NADNameAddress(['NAD', 'CN']);


### PR DESCRIPTION
## Summary
- add `ContextSegment` model to hold a segment and its children
- create `ContextStackParser` implementing stack-based grouping
- test new context stack parser functionality
