### PR TITLE
ParserResult combines global and transactional segments

### DIFF
--- a/src/IO/ConsolePrinter.php
+++ b/src/IO/ConsolePrinter.php
@@ -13,7 +13,6 @@ use function array_key_first;
 use function json_encode;
 use function sprintf;
 use function str_pad;
-use function str_repeat;
 
 final class ConsolePrinter implements PrinterInterface
 {

--- a/src/ParserResult.php
+++ b/src/ParserResult.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace EdifactParser;
 
+use EdifactParser\Segments\SegmentInterface;
+
 final class ParserResult
 {
+    use HasRetrievableSegments;
+
     /**
      * @param list<TransactionMessage> $transactionMessages
      */
@@ -23,5 +27,28 @@ final class ParserResult
     public function transactionMessages(): array
     {
         return $this->transactionMessages;
+    }
+
+    /**
+     * Combine global and transactional segments in one array.
+     *
+     * @return array<string, array<string, SegmentInterface>>
+     */
+    public function allSegments(): array
+    {
+        $all = $this->globalSegments->allSegments();
+
+        foreach ($this->transactionMessages as $message) {
+            foreach ($message->allSegments() as $tag => $segments) {
+                if (!isset($all[$tag])) {
+                    $all[$tag] = [];
+                }
+                foreach ($segments as $subId => $segment) {
+                    $all[$tag][$subId] = $segment;
+                }
+            }
+        }
+
+        return $all;
     }
 }

--- a/tests/Unit/ParserResultTest.php
+++ b/tests/Unit/ParserResultTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EdifactParser\Tests\Unit;
+
+use EdifactParser\EdifactParser;
+use EdifactParser\Segments\CNTControl;
+use EdifactParser\Segments\UNBInterchangeHeader;
+use PHPUnit\Framework\TestCase;
+
+final class ParserResultTest extends TestCase
+{
+    /**
+     * @psalm-suppress InvalidArrayOffset
+     */
+    public function test_retrieve_segments_across_global_and_messages(): void
+    {
+        $fileContent = <<<EDI
+UNA:+.? '
+UNB+UNOC:3+1234567890123+9876543210987+250506:1300+ORDER001'
+UNH+1+ORDERS:D:96A:UN:EAN008'
+CNT+2:2'
+UNT+13+1'
+UNZ+1+ORDER001'
+EDI;
+        $parserResult = EdifactParser::createWithDefaultSegments()->parse($fileContent);
+
+        $unb = $parserResult->segmentByTagAndSubId('UNB', 'UNOC');
+        self::assertInstanceOf(UNBInterchangeHeader::class, $unb);
+
+        $cntSegments = $parserResult->segmentsByTag('CNT');
+        self::assertArrayHasKey('2', $cntSegments);
+        self::assertInstanceOf(CNTControl::class, $cntSegments['2']);
+    }
+}


### PR DESCRIPTION

## 🔖 Changes

- Added a new method in ParserResult that combines global and transactional segments so segments can be retrieved directly from the parser result object

- Created a unit test verifying retrieval of segments across global and transaction messages using the new API
